### PR TITLE
Changing the Menagea3 plugin

### DIFF
--- a/dosagelib/plugins/m.py
+++ b/dosagelib/plugins/m.py
@@ -121,7 +121,7 @@ class MenageA3(_BasicScraper):
     url = 'http://www.ma3comic.com/'
     stripUrl = url + 'strips-ma3/%s'
     imageSearch = compile(tagre("img", "src", r'([^"]*/comics/[^"]+)'))
-    prevSearch = compile(tagre("a", "href", r'([^"]*/strips-ma3/[^"]+)',
+    prevSearch = compile(tagre("a", "href", r'([^"]*/comics/[^"]+)',
                                before="cn[id]prev"))
     help = 'Index format: name'
 


### PR DESCRIPTION
I've changed the menagea3 plugin so it should work with the new directory structure found on the site. From what I've been able to determine all of the webcomics are hosted from the comics folder so the strips-ma3 folder is no longer necessary.