### PR TITLE
add a comic plugin for CommitStrip

### DIFF
--- a/dosagelib/plugins/c.py
+++ b/dosagelib/plugins/c.py
@@ -175,6 +175,31 @@ class Comedity(_BasicScraper):
     help = 'Index format: n (no padding)'
 
 
+class CommitStrip(_ParserScraper):
+    baseUrl = 'https://www.commitstrip.com/en/'
+    url = baseUrl + '?setLocale=1' # ensure the language cookie is set
+    stripUrl = baseUrl + '%s/'
+    firstStripUrl = 'http://www.commitstrip.com/en/2012/02/22/interview/' # non-TLS!
+
+    latestSearch = '//section//a'
+    starter = indirectStarter
+    imageSearch = '//article/div//img'
+    prevSearch = '//span[@class="nav-previous"]/a'
+    help = 'Index format: yyyy/mm/dd/strip-name'
+
+    def namer(self, image_url, page_url):
+        parts = page_url.rstrip('/').rsplit('/')[-4:]
+        return '-'.join(parts)
+
+
+class CommitStripFr(CommitStrip):
+    baseUrl = 'https://www.commitstrip.com/fr/'
+    url = baseUrl + '?setLocale=1' # ensure the language cookie is set
+    stripUrl = baseUrl + '%s/'
+    firstStripUrl = 'http://www.commitstrip.com/fr/2012/02/22/interview/' # non-TLS!
+    lang = 'fr'
+
+
 class CompanyY(_BasicScraper):
     url = 'http://company-y.com/'
     rurl = escape(url)


### PR DESCRIPTION
Implements both English and French version of CommitStrip.

Images are saved under the page URL, which is mostly useful, but often in the wrong language. At the moment, all page URLs are in English. Ideally, the files would be named after the in-HTML heading on the page.

Currently only the first image of each post is downloaded. This is wrong in some cases, because some posts contain a non-comic image before the comic. Though most of the time, it works correctly. Since it is pretty much impossible to detect which of the images is the comic, we might in the future download all images and name the files sequentially. 

I reckon a mostly-working implementation is much better than no support at all.