### PR TITLE
Fix Gunnerkrigg Court prevSearch matcher

### DIFF
--- a/dosagelib/plugins/g.py
+++ b/dosagelib/plugins/g.py
@@ -170,12 +170,12 @@ class GUComics(_BasicScraper):
 
 
 class GunnerkriggCourt(_BasicScraper):
-    url = 'http://www.gunnerkrigg.com/'
+    url = 'https://www.gunnerkrigg.com/'
     stripUrl = url + '?p=%s'
     imageSearch = compile(tagre("img", "src", r'(/comics/[^"]+)'))
     prevSearch = compile(
         tagre("a", "href", r'(\?p=\d+)') +
-        tagre("img", "src", "http://www\.gunnerkrigg\.com/images/prev_a\.jpg"))
+        tagre("img", "src", "/images/prev_a\.jpg"))
     help = 'Index format: number'
 
 


### PR DESCRIPTION
The image URL for the back button has changed, removing domain name etc., resulting in the following error:

```
GunnerkriggCourt> WARN: Patterns ['<\\s*[aA]\\s+(?:[^>]*\\s+)?[hH][rR][eE][fF]\\s*=\\s*"(\\?p=\\d+)"[^>]*[^>]*><\\s*[iI][mM][gG]\\s+(?:[^>]*\\s+)?[sS][rR][cC]\\s*=\\s*"http://www\\.gunnerkrigg\\.com/images/prev_a\\.jpg"[^>]*[^>]*>'] not found at URL http://www.gunnerkrigg.com/. Assuming no previous comic strips exist.
```

This change makes it work again.