### PR TITLE
Add comic "turnoff"

### DIFF
--- a/dosagelib/plugins/t.py
+++ b/dosagelib/plugins/t.py
@@ -188,6 +188,16 @@ class TumbleDryComics(_WordPressScraper):
         return filename
 
 
+class Turnoff(_ParserScraper):
+    name = 'turnoff'
+    url = 'https://turnoff.us/'
+    imageSearch = '//article[%s]//img' % xpath_class('post-content')
+    prevSearch = '//div[%s]//a' % xpath_class('prev')
+    stripUrl = url + 'geek/%s'
+    firstStripUrl = stripUrl % 'tcp-buddies'
+    multipleImagesPerStrip = True
+
+
 class TwoGuysAndGuy(_BasicScraper):
     url = 'http://www.twogag.com/'
     rurl = escape(url)


### PR DESCRIPTION
Giving the comics decent names was a bit hacky.
I extracted the list of the comics from the JavaScript code, and used it to compute an index for each one. Otherwise the comics are just sorted alphabetically.