### PR TITLE
Add 12 comics, fix bug in WebToons completion detection

### DIFF
--- a/dosagelib/plugins/c.py
+++ b/dosagelib/plugins/c.py
@@ -55,6 +55,7 @@ class CarryOnAliceBlueAndTheGardensOfQ(CarryOn):
     url = 'http://www.hirezfox.com/km/abgq/abgq1024/'
     stripUrl = url + 'd/%s.html'
     firstStripUrl = stripUrl % '20050401'
+    endOfLife = True
 
     def namer(self, imageUrl, pageUrl):
         # Fix filenames
@@ -66,6 +67,7 @@ class CarryOnLegendOfAnneBunny(CarryOn):
     url = 'http://www.hirezfox.com/km/loab/loab1024/'
     stripUrl = url + 'd/%s.html'
     firstStripUrl = stripUrl % '20040701'
+    endOfLife = True
 
     def namer(self, imageUrl, pageUrl):
         # Fix filenames of early comics

--- a/dosagelib/plugins/comicfury.py
+++ b/dosagelib/plugins/comicfury.py
@@ -1134,6 +1134,7 @@ class ComicFury(_ParserScraper):
             cls('UltimateSwordsSummoner', 'uss'),
             cls('UltraViresEnglish', 'ultravires-eng'),
             cls('UltraViresesky', 'ultravires'),
+            cls('Unconventional', 'unconventional', adult=True),
             cls('Underverse', 'underverse'),
             cls('UnfortunateCircumstances', 'unfortunatecircumstances'),
             cls('UniversityOfSpeed', 'u-speed'),

--- a/dosagelib/plugins/comicfury.py
+++ b/dosagelib/plugins/comicfury.py
@@ -550,6 +550,7 @@ class ComicFury(_ParserScraper):
             cls('ItsComplicated', 'itscomplicated'),
             cls('ItsJustAnotherDay', 'itsjustanotherday'),
             cls('ItsNEWDAY', 'itsnewday'),
+            cls('Jack', 'jackrabbit', adult=True),
             cls('JackAndTheBeanstalk', 'jackandthebeanstalk'),
             cls('JackFrostDoujin', 'jfdoujin'),
             cls('JackitAndFriends', 'jackitandfriends'),

--- a/dosagelib/plugins/d.py
+++ b/dosagelib/plugins/d.py
@@ -85,8 +85,8 @@ class DeepFried(_BasicScraper):
 
 
 class DeerMe(_ParserScraper):
-    url = 'http://deerme.net/'
-    stripUrl = url + 'comics/%s'
+    url = 'http://deerme.net/comics/'
+    stripUrl = url + '%s'
     firstStripUrl = stripUrl % '1'
     imageSearch = ('//img[@id="comicimage"]', '//img[@id="latestcomicimage"]')
     prevSearch = '//a[@rel="prev"]'

--- a/dosagelib/plugins/kemonocafe.py
+++ b/dosagelib/plugins/kemonocafe.py
@@ -50,6 +50,7 @@ class KemonoCafe(_ParserScraper):
             cls('CaribbeanBlue', 'cb', 'page000', last='page325'),
             cls('IMew', 'imew', 'imew00', last='imew50'),
             cls('Knighthood', 'knighthood', 'kh0001'),
+            cls('KnuckleUp', 'knuckle-up', 'page001', adult=True),
             cls('LasLindas', 'laslindas', 'll0001', adult=True),
             cls('Paprika', 'paprika', 'page000'),
             cls('PracticeMakesPerfect', 'pmp', 'title-001'),

--- a/dosagelib/plugins/mangadex.py
+++ b/dosagelib/plugins/mangadex.py
@@ -82,6 +82,7 @@ class MangaDex(_ParserScraper):
             cls('JingaiNoYomeToIchaIchaSuru', 22651),
             cls('KawaiiJoushiWoKomarasetai', 17910),
             cls('KanojoOkarishimasu', 22151),
+            cls('MaouNoOreGaDoreiElfWoYomeNiShitandaGaDouMederebaIi', 25495),
             cls('ModernMoGal', 30308),
             cls('OMaidensinYourSavageSeason', 22030),
             cls('OokamiShounenWaKyouMoUsoOKasaneru', 14569),

--- a/dosagelib/plugins/mangadex.py
+++ b/dosagelib/plugins/mangadex.py
@@ -82,6 +82,7 @@ class MangaDex(_ParserScraper):
             cls('JingaiNoYomeToIchaIchaSuru', 22651),
             cls('KawaiiJoushiWoKomarasetai', 17910),
             cls('KanojoOkarishimasu', 22151),
+            cls('Lv2KaraCheatDattaMotoYuushaKouhoNoMattariIsekaiLife', 33797),
             cls('MaouNoOreGaDoreiElfWoYomeNiShitandaGaDouMederebaIi', 25495),
             cls('ModernMoGal', 30308),
             cls('OMaidensinYourSavageSeason', 22030),

--- a/dosagelib/plugins/mangadex.py
+++ b/dosagelib/plugins/mangadex.py
@@ -79,6 +79,7 @@ class MangaDex(_ParserScraper):
             cls('HoriMiya', 6770),
             cls('HowToOpenATriangularRiceball', 19305),
             cls('InterspeciesReviewers', 20796),
+            cls('JahySamaWaKujikenai', 22369),
             cls('JingaiNoYomeToIchaIchaSuru', 22651),
             cls('KawaiiJoushiWoKomarasetai', 17910),
             cls('KanojoOkarishimasu', 22151),

--- a/dosagelib/plugins/mangadex.py
+++ b/dosagelib/plugins/mangadex.py
@@ -93,6 +93,7 @@ class MangaDex(_ParserScraper):
             cls('PleaseTellMeGalkochan', 12702),
             cls('SaekiSanWaNemutteru', 28834),
             cls('SewayakiKitsuneNoSenkoSan', 22723),
+            cls('SousouNoFrieren', 48045),
             cls('SPYxFAMILY', 35705),
             cls('SwordArtOnline', 1360),
             cls('SwordArtOnlineProgressive', 9604),

--- a/dosagelib/plugins/mangadex.py
+++ b/dosagelib/plugins/mangadex.py
@@ -77,6 +77,7 @@ class MangaDex(_ParserScraper):
             cls('HangingOutWithAGamerGirl', 42490),
             cls('HeavensDesignTeam', 27811),
             cls('HoriMiya', 6770),
+            cls('HowToOpenATriangularRiceball', 19305),
             cls('InterspeciesReviewers', 20796),
             cls('JingaiNoYomeToIchaIchaSuru', 22651),
             cls('KawaiiJoushiWoKomarasetai', 17910),

--- a/dosagelib/plugins/o.py
+++ b/dosagelib/plugins/o.py
@@ -128,14 +128,13 @@ class OrderOfTheBlackDog(_WordPressScraper):
 
 
 class OriginalLife(_ParserScraper):
-    url = 'http://jaynaylor.com/originallife/'
+    url = 'https://web.archive.org/web/20200201203404/http://jaynaylor.com/originallife/'
     stripUrl = url + 'archives/%s.html'
     firstStripUrl = stripUrl % '2009/06/001'
     imageSearch = '//img[contains(@src, "/originallife/comic/")]'
     prevSearch = '//a[contains(text(), "Previous")]'
     adult = True
     endOfLife = True
-    help = 'Index format: yyyy/mm/<your guess>'
 
 
 class OurHomePlanet(_ParserScraper):

--- a/dosagelib/plugins/t.py
+++ b/dosagelib/plugins/t.py
@@ -23,6 +23,12 @@ class TailsAndTactics(_ParserScraper):
     prevSearch = '//a[text()=" Back"]'
 
 
+class TekMage(_WPNavi):
+    url = 'https://tekmagecomic.com/'
+    stripUrl = url + 'comic/%s/'
+    firstStripUrl = stripUrl % 'chapter-1-page-1'
+
+
 class Tamberlane(_WPWebcomic):
     baseUrl = 'https://www.tamberlanecomic.com/'
     url = baseUrl + 'latest/'

--- a/dosagelib/plugins/webtoons.py
+++ b/dosagelib/plugins/webtoons.py
@@ -127,6 +127,7 @@ class WebToons(_ParserScraper):
             cls('DEADDAYS', 'horror/dead-days', 293),
             cls('Debunkers', 'challenge/debunkers', 148475),
             cls('DEEP', 'thriller/deep', 364),
+            cls('Defects', 'challenge/defects', 221106),
             cls('Denma', 'sf/denma', 921),
             cls('Dents', 'sf/dents', 671),
             cls('Deor', 'fantasy/deor', 1663),

--- a/dosagelib/plugins/webtoons.py
+++ b/dosagelib/plugins/webtoons.py
@@ -380,6 +380,7 @@ class WebToons(_ParserScraper):
             cls('Thornstone', 'fantasy/thornstone', 1612),
             cls('TickleTown', 'comedy/tickle-town', 428),
             cls('ToasterDude', 'comedy/toaster-dude', 1983),
+            cls('TokyoThreatDocumentationProject', 'challenge/tokyo-threat-documentation-project', 417973),
             cls('TowerOfGod', 'fantasy/tower-of-god', 95),
             cls('TrailerParkWarlock', 'comedy/trailer-park-warlock', 1512),
             cls('TrashBird', 'comedy/trash-bird', 473),

--- a/dosagelib/plugins/webtoons.py
+++ b/dosagelib/plugins/webtoons.py
@@ -283,6 +283,7 @@ class WebToons(_ParserScraper):
             cls('OhHoly', 'romance/oh-holy', 809),
             cls('ORANGEMARMALADE', 'romance/orange-marmalade', 97),
             cls('Outrage', 'super-hero/outrage', 1450),
+            cls('OVERPOWERED', 'challenge/overpowered', 85292),
             cls('PacificRimAmara', 'sf/pacific-rim-amara', 1327),
             cls('PenguinLovesMev', 'slice-of-life/penguin-loves-mev', 86),
             cls('PhantomParadise', 'fantasy/phantom-paradise', 1250),

--- a/dosagelib/plugins/webtoons.py
+++ b/dosagelib/plugins/webtoons.py
@@ -25,7 +25,7 @@ class WebToons(_ParserScraper):
         listPage = self.getPage(self.listUrl)
         currentEpisode = listPage.xpath('//div[@class="detail_lst"]/ul/li')[0].attrib['data-episode-no']
         # Check for completed tag
-        self.endOfLife = (listPage.xpath('//span[@class="txt_ico_completed2"]') != [])
+        self.endOfLife = (listPage.xpath('//div[@id="_asideDetail"]//span[@class="txt_ico_completed2"]') != [])
         return self.stripUrl % currentEpisode
 
     def fetchUrls(self, url, data, urlSearch):


### PR DESCRIPTION
- Add MangaDex/JahySamaWaKujikenai
- Add TekMage
- Add ComicFury/Jack
- Add KemonoCafe/KnuckleUp
- Fix BetterDays and OriginalLife
- Mark CarryOn alt comics as endOfLife
- Add MangaDex/Lv2KaraCheatDattaMotoYuushaKouhoNoMattariIsekaiLife
- Add MangaDex/MaouNoOreGaDoreiElfWoYomeNiShitandaGaDouMederebaIi
- Add WebToons/TokyoThreatDocumentationProject
- Add MangaDex/SousouNoFrieren
- Add MangaDex/HowToOpenATriangularRiceball
- Fix WebToons completion detection
- Add WebToons/OVERPOWERED
- Add WebToons/Defects
- Fix DeerMe
- Add Unconventional