### PR TITLE
Support Widdershins as it no longer updates GoComics

### DIFF
--- a/dosagelib/plugins/w.py
+++ b/dosagelib/plugins/w.py
@@ -117,6 +117,16 @@ class WhyTheLongFace(_BasicScraper):
     help = 'Index format: yyyymm'
 
 
+class Widdershins(_ComicControlScraper):
+    url = 'https://widdershinscomic.com/'
+    stripUrl = url + 'wdshn/%s'
+    firstStripUrl = stripUrl % 'sleight-of-hand-cover'
+    starter = bounceStarter
+
+    def namer(self, imageUrl, pageUrl):
+        return pageUrl.rsplit('/', 1)[-1] + '.' + imageUrl.rsplit('.', 1)[-1]
+
+
 class Wigu(_ParserScraper):
     stripUrl = 'http://www.wigucomics.com/adventures/index.php?comic=%s'
     url = stripUrl % '-1'


### PR DESCRIPTION
[Widdershins stopped updating on GoComics in December 2020](https://www.gocomics.com/widdershins/2020/12/08).
However, the comic has been [regularly updated since](https://www.widdershinscomic.com/wdshn/may-20th-2022)
on the main comic site. This commit adds a plugin for the main site.
I've verified that it can scrape all comics, including recent ones not
on GoComics.

I haven't removed the GoComics/Widdershins plugin as part of this PR - happy to do so if that is now redundant.