### PR TITLE
Sluggy Freelance - Changing from HTTP to HTTPS

### DIFF
--- a/dosagelib/plugins/s.py
+++ b/dosagelib/plugins/s.py
@@ -302,8 +302,8 @@ class SlightlyDamned(ComicControlScraper):
 
 
 class SluggyFreelance(_ParserScraper):
-    url = 'http://sluggy.com/'
-    stripUrl = 'http://archives.sluggy.com/book.php?chapter=%s'
+    url = 'https://sluggy.com/'
+    stripUrl = 'https://archives.sluggy.com/book.php?chapter=%s'
     firstStripUrl = stripUrl % '1'
     imageSearch = '//div[d:class("comic_content")]/img/@data-src'
     prevSearch = '//div[d:class("previous")]/a'


### PR DESCRIPTION
Error occurring:
SluggyFreelance> ERROR: HTTPConnectionPool(host='sluggy.com', port=80): Max retries exceeded with url: / (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x000002B2E5A4A7D0>, 'Connection to sluggy.com timed out. (connect timeout=None)'))

Last successful Dosage pull was sometime in early October 2022 (Approx 07-Oct-2022).

Identified to be that Sluggy.com is no longer delivering content on port 80 HTTP version of site, and does not have an HSTS redirect any longer to the 443 HTTPS version of site. 443 HTTPS version of site correctly hosts content.

Updated Class to https instead of http.