### PR TITLE
PoorlyDrawnLines: Fix after site redesign

### DIFF
--- a/dosagelib/plugins/p.py
+++ b/dosagelib/plugins/p.py
@@ -228,13 +228,36 @@ class PokeyThePenguin(_ParserScraper):
         prefix = url.rsplit('/', 1)[0]
         return "%s/index%d.html" % (prefix, num)
 
-
 class PoorlyDrawnLines(_ParserScraper):
-    url = 'http://poorlydrawnlines.com/comic/'
-    firstStripUrl = url + 'campus-characters/'
-    imageSearch = '//div[d:class("comic")]//img'
+    url = 'https://poorlydrawnlines.com/comic/'
+    stripUrl = url + '%s/'
+    multipleImagesPerStrip = True
+    firstStripUrl = stripUrl % 'hardly-essayists'
+    imageSearch = '//div[d:class("entry-content")]//img[@data-src]/@data-src'
     prevSearch = '//a[@rel="prev"]'
 
+    def shouldSkipUrl(self, url, _data):
+        """Skip pages without a comic."""
+        skipUrls = [self.stripUrl % s for s in (
+            'hope-it-all-works-out-new-book-coming-this-fall',
+            'poorly-drawn-lines-animated-series',
+            'poorly-drawn-lines-episode-two',
+            'watch-poorly-drawn-lines-on-hulu',
+        )]
+        return url in skipUrls
+
+    def getPrevUrl(self, url: str, data):
+        """Skip missing comics which redirect back to home page"""
+        if url == self.stripUrl % '8198':
+            return self.stripUrl % 'excited-2'
+        elif url == self.stripUrl % '8186':
+            return self.stripUrl % 'to-hell-2'
+        elif url == self.stripUrl % '8177':
+            return self.stripUrl % 'feel-real'
+        elif url == self.stripUrl % '2056':
+            return self.stripUrl % 'stereotype'
+
+        return super().getPrevUrl(url, data)
 
 class PoppyOPossum(WordPressScraper):
     baseUrl = 'https://www.poppy-opossum.com/'

--- a/dosagelib/plugins/p.py
+++ b/dosagelib/plugins/p.py
@@ -5,10 +5,10 @@
 # SPDX-FileCopyrightText: © 2019 Daniel Ring
 from re import compile, escape
 
-from ..scraper import _BasicScraper, _ParserScraper, ParserScraper
-from ..helpers import bounceStarter, queryNamer, indirectStarter
+from ..helpers import bounceStarter, indirectStarter, joinPathPartsNamer, queryNamer
+from ..scraper import ParserScraper, _BasicScraper, _ParserScraper
 from ..util import tagre
-from .common import ComicControlScraper, WordPressScraper, WordPressNavi
+from .common import ComicControlScraper, WordPressNavi, WordPressScraper
 
 
 class PandyLand(_ParserScraper):
@@ -228,13 +228,15 @@ class PokeyThePenguin(_ParserScraper):
         prefix = url.rsplit('/', 1)[0]
         return "%s/index%d.html" % (prefix, num)
 
-class PoorlyDrawnLines(_ParserScraper):
-    url = 'https://poorlydrawnlines.com/comic/'
-    stripUrl = url + '%s/'
+
+class PoorlyDrawnLines(ParserScraper):
+    url = 'https://poorlydrawnlines.com/'
+    stripUrl = url + 'comic/%s/'
     multipleImagesPerStrip = True
     firstStripUrl = stripUrl % 'hardly-essayists'
-    imageSearch = '//div[d:class("entry-content")]//img[@data-src]/@data-src'
+    imageSearch = '//div[d:class("entry-content")]//img'
     prevSearch = '//a[@rel="prev"]'
+    namer = joinPathPartsNamer(imageparts=range(-3, 0))
 
     def shouldSkipUrl(self, url, _data):
         """Skip pages without a comic."""
@@ -258,6 +260,7 @@ class PoorlyDrawnLines(_ParserScraper):
             return self.stripUrl % 'stereotype'
 
         return super().getPrevUrl(url, data)
+
 
 class PoppyOPossum(WordPressScraper):
     baseUrl = 'https://www.poppy-opossum.com/'


### PR DESCRIPTION
Hi folks. [Poorly Drawn Lines](https://poorlydrawnlines.com) seems to have had a recent redesign and is no longer working. This is a WIP fix, but I've hit an issue. Some pages are non-comic, e.g. [promos for the TV show of the comic](https://poorlydrawnlines.com/comic/watch-poorly-drawn-lines-on-hulu/). These currently generate an error and bail out. I'm haven't found a way to suppress this for known pages without comics. Any advice here appreciated!

A few other notes:
* The redesign uses WordPress, but doesn't fit any existing WP scrapers
* There are [some recent pages with 2 comic images](https://poorlydrawnlines.com/comic/finish-my-book/), so this now sets `multipleImagesPerStrip`
* The comic now loads with dynamic resolution using inline SVG, so I'm checking data-src instead
* I'd be happy for feedback on specificity vs. robustness. The DOM tree and classes aren't always consistent. I've tried to work around this without pulling in other images. Still, feels a _little_ flaky.