### PR TITLE
Migrate home-grown logging to stdlib logging (fixes #309)

### DIFF
--- a/dosagelib/__init__.py
+++ b/dosagelib/__init__.py
@@ -13,17 +13,18 @@ your intentions, and received permission to distribute.
 The primary interface is the 'dosage' commandline script.
 Comic modules for each comic are located in L{dosagelib.plugins}.
 """
-
+import logging
 from importlib import metadata
 
-from .output import out
+from . import logext  # noqa: F401 - needed here to preload logging extensions
+
+logger = logging.getLogger(__name__)
 
 AppName = 'dosage'
 try:
     __version__ = metadata.version(AppName)  # PEP 396
 except metadata.PackageNotFoundError:
     # package is not installed
-    out.warn('{} is not installed, no version available.'
-        ' Use at least {!r} or {!r} to fix this.'.format(
-            AppName, 'pip install -e .', 'setup.py egg_info'))
+    logger.warning('%s is not installed, no version available.'
+        ' Use something like %r to fix this.', AppName, 'pip install -e .')
     __version__ = 'ERR.NOT.INSTALLED'

--- a/dosagelib/director.py
+++ b/dosagelib/director.py
@@ -1,19 +1,21 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2004-2008 Tristan Seligmann and Jonathan Jacobs
-# Copyright (C) 2012-2014 Bastian Kleineidam
-# Copyright (C) 2015-2022 Tobias Gruetzmacher
-# Copyright (C) 2019-2020 Daniel Ring
+# SPDX-FileCopyrightText: © 2004 Tristan Seligmann and Jonathan Jacobs
+# SPDX-FileCopyrightText: © 2012 Bastian Kleineidam
+# SPDX-FileCopyrightText: © 2015 Tobias Gruetzmacher
+# SPDX-FileCopyrightText: © 2019 Daniel Ring
+import _thread
+import logging
 import os
 import re
 import threading
-import _thread
-from queue import Queue, Empty
+from queue import Empty, Queue
 from typing import Collection, Dict
 from urllib.parse import urlparse
 
-from .output import out
-from .scraper import scrapers as scrapercache
 from . import events
+from .scraper import scrapers as scrapercache
+
+logger = logging.getLogger(__name__)
 
 
 class ComicQueue(Queue):
@@ -106,13 +108,13 @@ class ComicGetter(threading.Thread):
             numstrips = 1
         try:
             if scraperobj.isComplete(self.options.basepath):
-                out.info(u"All comics are already downloaded.")
+                logger.info("All comics are already downloaded.")
                 return 0
             for strip in scraperobj.getStrips(numstrips):
                 skipped = self.saveComicStrip(strip)
                 if skipped and self.options.cont:
                     # stop when retrieval skipped an image for one comic strip
-                    out.info(u"Stop retrieval because image file already exists")
+                    logger.info("Stop retrieval because image file already exists")
                     break
                 if self.stopped:
                     break
@@ -122,7 +124,7 @@ class ComicGetter(threading.Thread):
                                             scraperobj.indexes):
                 scraperobj.setComplete(self.options.basepath)
         except Exception as msg:
-            out.exception(msg)
+            logger.exception(msg)  # noqa: G200 # FIXME: Legacy stuff, needs refactor
             self.errors += 1
 
     def saveComicStrip(self, strip):
@@ -139,8 +141,8 @@ class ComicGetter(threading.Thread):
                 if self.stopped:
                     break
             except Exception as msg:
-                out.exception('Could not save image at {} to {}: {!r}'.format(
-                    image.referrer, image.filename, msg))
+                logger.exception('Could not save image at %r to %r: %s',
+                    image.referrer, image.filename, msg)  # noqa: G200
                 self.errors += 1
         return allskipped
 
@@ -174,10 +176,10 @@ def getComics(options):
         for t in threads:
             errors += t.errors
     except ValueError as msg:
-        out.exception(msg)
+        logger.exception(msg)  # noqa: G200
         errors += 1
     except KeyboardInterrupt:
-        out.warn("Interrupted! Waiting for download threads to finish.")
+        logger.warning("Interrupted! Waiting for download threads to finish.")
     finally:
         for t in threads:
             t.stop()
@@ -192,7 +194,7 @@ def getScrapers(comics: Collection[str], basepath: str, adult=True, listing=Fals
     if '@' in comics:
         # only scrapers whose directory already exists
         if len(comics) > 1:
-            out.warn(u"using '@' as comic name ignores all other specified comics.")
+            logger.warning("using '@' as comic name ignores all other specified comics.")
         for comic in get_existing_comics(basepath, adult, listing):
             yield comic
     else:
@@ -245,11 +247,10 @@ def shouldRunScraper(scraperobj, adult=True, listing=False):
 
 def warn_adult(scraperobj):
     """Print warning about adult content."""
-    out.warn(u"skipping adult comic {};"
-        " use the --adult option to confirm your age".format(scraperobj.name))
+    logger.warning("skipping adult comic %s; use the --adult option to confirm your age",
+        scraperobj.name)
 
 
 def warn_disabled(scraperobj, reasons):
     """Print warning about disabled comic modules."""
-    out.warn(u"Skipping comic {}: {}".format(
-        scraperobj.name, ' '.join(reasons.values())))
+    logger.warning("Skipping comic %s: %s", scraperobj.name, ' '.join(reasons.values()))

--- a/dosagelib/events.py
+++ b/dosagelib/events.py
@@ -1,17 +1,19 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2004-2008 Tristan Seligmann and Jonathan Jacobs
-# Copyright (C) 2012-2014 Bastian Kleineidam
-# Copyright (C) 2015-2020 Tobias Gruetzmacher
+# SPDX-FileCopyrightText: © 2004 Tristan Seligmann and Jonathan Jacobs
+# SPDX-FileCopyrightText: © 2012 Bastian Kleineidam
+# SPDX-FileCopyrightText: © 2015 Tobias Gruetzmacher
+import codecs
+import json
+import logging
 import os
 import time
 from urllib.parse import quote as url_quote
-import codecs
-import json
 
 import imagesize
 
-from . import rss, util, configuration
-from .output import out
+from . import configuration, rss, util
+
+logger = logging.getLogger(__name__)
 
 # Maximum width or height to display an image in exported pages.
 # Note that only the displayed size is adjusted, not the image itself.
@@ -138,7 +140,8 @@ def getDimensionForImage(filename, maxsize):
     try:
         origsize = imagesize.get(filename)
     except Exception as e:
-        out.warn("Could not get image size of {}: {}".format(os.path.basename(filename), e))
+        logger.warning("Could not get image size of %r: %s",  # noqa: G200
+            os.path.basename(filename), e)
         return None
 
     width, height = origsize
@@ -150,7 +153,7 @@ def getDimensionForImage(filename, maxsize):
         height = round(maxsize[1])
 
     if width < origsize[0] or height < origsize[1]:
-        out.info("Downscaled display size from %s to %s" % (origsize, (width, height)))
+        logger.info("Downscaled display size from %s to %s", origsize, (width, height))
     return (width, height)
 
 
@@ -182,9 +185,9 @@ class HtmlEventHandler(EventHandler):
 
         fn = self.fnFromDate(today)
         if os.path.exists(fn):
-            out.warn('HTML output file %r already exists' % fn)
-            out.warn('the page link of previous run will skip this file')
-            out.warn('try to generate HTML output only once per day')
+            logger.warning('HTML output file %r already exists', fn)
+            logger.warning('the page link of previous run will skip this file')
+            logger.warning('try to generate HTML output only once per day')
             fn = util.getNonexistingFile(fn)
 
         d = os.path.dirname(fn)

--- a/dosagelib/loader.py
+++ b/dosagelib/loader.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2012-2014 Bastian Kleineidam
-# Copyright (C) 2016-2020 Tobias Gruetzmacher
+# SPDX-FileCopyrightText: © 2012 Bastian Kleineidam
+# SPDX-FileCopyrightText: © 2016 Tobias Gruetzmacher
 """
 Functions to load plugin modules.
 
@@ -9,11 +9,14 @@ Example usage:
         plugins.extend(loader.get_module_plugins(module, PluginClass))
 """
 import importlib
+import logging
 import pkgutil
 import sys
 
-from .plugins import (__name__ as plugin_package, __path__ as plugin_path)
-from .output import out
+from .plugins import __name__ as plugin_package
+from .plugins import __path__ as plugin_path
+
+logger = logging.getLogger(__name__)
 
 
 def get_plugin_modules():
@@ -31,8 +34,8 @@ def get_plugin_modules():
     for name in modules:
         try:
             yield importlib.import_module(name)
-        except ImportError as msg:
-            out.error("could not load module %s: %s" % (name, msg))
+        except ImportError:
+            logger.exception("could not load module %s", name)
 
 
 def _get_all_modules_pyinstaller():

--- a/dosagelib/logext.py
+++ b/dosagelib/logext.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2025 Tobias Gruetzmacher
+
+import logging
+from typing import TYPE_CHECKING
+
+MOREINFO = 15
+TRACE = 5
+
+if TYPE_CHECKING:
+    parentlogger = logging.Logger
+else:
+    parentlogger = logging.getLoggerClass()
+
+class ExtLogger(parentlogger):
+    def moreinfo(self, msg, *args, **kwargs):
+        if self.isEnabledFor(MOREINFO):
+            self._log(MOREINFO, msg, args, **kwargs)
+
+    def trace(self, msg, *args, **kwargs):
+        if self.isEnabledFor(TRACE):
+            self._log(TRACE, msg, args, **kwargs)
+
+
+logging.addLevelName(MOREINFO, "MOREINFO")
+logging.addLevelName(TRACE, "TRACE")
+logging.setLoggerClass(ExtLogger)

--- a/dosagelib/plugins/tapas.py
+++ b/dosagelib/plugins/tapas.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: © 2019 Tobias Gruetzmacher
 # SPDX-FileCopyrightText: © 2019 Daniel Ring
-from ..output import out
+import logging
+
 from ..scraper import ParserScraper
+
+logger = logging.getLogger(__name__)
 
 
 class Tapas(ParserScraper):
@@ -43,7 +46,7 @@ class Tapas(ParserScraper):
 
     def shouldSkipUrl(self, url, data):
         if self.match(data, '//button[d:class("js-have-to-sign")]'):
-            out.warn(f'Nothing to download on "{url}", because a login is required.')
+            logger.warning('Nothing to download on %r, because a login is required.', url)
             return True
         return False
 

--- a/dosagelib/singleton.py
+++ b/dosagelib/singleton.py
@@ -2,14 +2,16 @@
 # Copied from: https://github.com/pycontribs/tendo
 # Author: Sorin Sbarnea
 # Changes: changed logging and formatting
-import sys
-import os
 import errno
+import logging
+import os
+import sys
 import tempfile
-from .output import out
+
+logger = logging.getLogger(__name__)
 
 
-class SingleInstance(object):
+class SingleInstance:
     """
     To prevent a script from running in parallel instantiate the
     SingleInstance() class. If is there another instance
@@ -37,7 +39,7 @@ class SingleInstance(object):
         lockname += '.lock'
         tempdir = tempfile.gettempdir()
         self.lockfile = os.path.normpath(os.path.join(tempdir, lockname))
-        out.debug("SingleInstance lockfile: " + self.lockfile)
+        logger.debug("SingleInstance lockfile: %s", self.lockfile)
         if sys.platform == 'win32':
             try:
                 # file already exists, try to remove it in case the previous
@@ -62,7 +64,7 @@ class SingleInstance(object):
 
     def exit(self, exit_code):
         """Exit with an error message and the given exit code."""
-        out.error("Another instance is already running, quitting.")
+        logger.error("Another instance is already running, quitting.")
         sys.exit(exit_code)
 
     def __del__(self):
@@ -79,5 +81,5 @@ class SingleInstance(object):
                 fcntl.lockf(self.fp, fcntl.LOCK_UN)
                 if os.path.isfile(self.lockfile):
                     os.unlink(self.lockfile)
-        except Exception as e:
-            out.exception("could not remove lockfile: %s" % e)
+        except Exception:
+            logger.exception("could not remove lockfile")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ classifiers = [
 keywords = ["comic", "webcomic", "downloader", "archiver", "crawler"]
 requires-python = ">=3.8"
 dependencies = [
-    "colorama",
     "imagesize",
     "lxml>=4.0.0",
     "platformdirs",
     "requests>=2.0",
+    "rich",
     "importlib_resources>=5.0.0;python_version<'3.9'",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This uses rich for all console formatting & coloring, so we get rid of quite a lot custom terminal handling code.

This still has some issues:
- [x] Listing all comic modules is slow
- [x] Columns in the listing are... strange
- [x] Not much (manual) testing has been done