### PR TITLE
Ignore "global" rules in robots.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,22 @@ is purely for personal use. Please be aware that by making downloaded strips
 publically available (without the explicit permission of the author) you may be
 infringing upon various copyrights.
 
-Additionally, Dosage respects the robots.txt exclusion protocol. This makes
-sure no content is accessed in an automatic way without consent by the
-publishers.
-
 In any case, you should support the authors of the comics you are downloading,
 either by buying some of their products or even donating them some money since
 they provide the comics you like and read.
 
-If you are a publisher of comics and want Dosage to access your files,
-add the following entry to your robots.txt file:
+Additionally, Dosage respects (part of) the `robots.txt` exclusion protocol.
+This makes it easy for publishers to disallow Dosage access to their site. On
+the other hand, Dosage is no classic "crawler" oder "bot", so global rules in
+`robots.txt` are ignored.
+
+If you are a publisher of comics and don't want Dosage to access your files,
+either open an issue and request removal (this is the preferred solution, since
+it documents your wishes to us) or add the following entry to your robots.txt
+file:
 
     User-agent: Dosage
-    Allow: *
+    Disallow: *
 
 ## Usage
 

--- a/scripts/keenspot.py
+++ b/scripts/keenspot.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2004-2008 Tristan Seligmann and Jonathan Jacobs
-# Copyright (C) 2012-2014 Bastian Kleineidam
-# Copyright (C) 2015-2020 Tobias Gruetzmacher
-# Copyright (C) 2019-2020 Daniel Ring
+# SPDX-FileCopyrightText: © 2004 Tristan Seligmann and Jonathan Jacobs
+# SPDX-FileCopyrightText: © 2012 Bastian Kleineidam
+# SPDX-FileCopyrightText: © 2015 Tobias Gruetzmacher
+# SPDX-FileCopyrightText: © 2019 Daniel Ring
 """
 Script to get a list of KeenSpot comics and save the info in a
 JSON file for further processing.
 """
 
-from urllib.parse import urlsplit
+from urllib import parse
 
 from scriptutil import ComicListUpdater
-from dosagelib.util import check_robotstxt
+from dosagelib import http
 
 
 class KeenSpotUpdater(ComicListUpdater):
@@ -47,9 +47,9 @@ class KeenSpotUpdater(ComicListUpdater):
             name = comiclink.xpath('string()')
             try:
                 if '/d/' not in comicurl:
-                    check_robotstxt(comicurl + 'd/', self.session)
+                    http.check_robotstxt(comicurl + 'd/', self.session)
                 else:
-                    check_robotstxt(comicurl, self.session)
+                    http.check_robotstxt(comicurl, self.session)
             except IOError as e:
                 print('[%s] INFO: robots.txt denied: %s' % (name, e))
                 continue
@@ -57,7 +57,7 @@ class KeenSpotUpdater(ComicListUpdater):
             self.add_comic(name, comicurl)
 
     def get_entry(self, name, url):
-        sub = urlsplit(url).hostname.split('.', 1)[0]
+        sub = parse.urlsplit(url).hostname.split('.', 1)[0]
         if name in self.extra:
             extra = ', ' + self.extra[name]
         else:

--- a/tests/test_robotstxt.py
+++ b/tests/test_robotstxt.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2025 Tobias Gruetzmacher
+import pytest
+import requests
+import responses
+
+from dosagelib import http
+
+
+@responses.activate
+def test_no_robotstxt():
+    responses.get('http://a/robots.txt', status=404)
+    http.check_robotstxt("http://a/somefile.html", requests.Session())
+
+
+@responses.activate
+def test_err_robotstxt():
+    responses.get('http://b/robots.txt', body=IOError("Timeout!"))
+    http.check_robotstxt("http://b/somefile.html", requests.Session())
+
+
+@responses.activate
+def test_empty_robotstxt():
+    responses.get('http://c/robots.txt')
+    http.check_robotstxt("http://c/somefile.html", requests.Session())
+
+
+@responses.activate
+def test_allowed_robotstxt():
+    responses.get('http://d/robots.txt', body="User-agent: *\nDisallow:")
+    http.check_robotstxt("http://d/somefile.html", requests.Session())
+
+
+@responses.activate
+def test_all_denied_robotstxt():
+    responses.get('http://e/robots.txt', body="User-agent: *\nDisallow: /")
+    http.check_robotstxt("http://e/somefile.html", requests.Session())
+
+
+@responses.activate
+def test_explit_denied_robotstxt():
+    responses.get('http://f/robots.txt', body="User-agent: dosage\nDisallow: /")
+    with pytest.raises(IOError):  # noqa: PT011 # FIXME: Refactor code to use another exception?
+        http.check_robotstxt("http://f/somefile.html", requests.Session())


### PR DESCRIPTION
We still keep around our robots.txt parsing and document how publishers/authors can opt out of being listed in Dosage, but let's move a bit more into the direction of other "user-controlled" downloading tools like gallery-dl or yt-dlp, which both ignore robots.txt outright...