### PR TITLE
Add LeastICouldDoBeginnings scraper for Sunday strips

### DIFF
--- a/dosagelib/plugins/l.py
+++ b/dosagelib/plugins/l.py
@@ -54,6 +54,28 @@ class LeastICouldDo(ParserScraper):
     starter = indirectStarter
     help = 'Index format: yyyymmdd'
 
+class LeastICouldDoBeginnings(_ParserScraper):
+    @property
+    def url(self):
+        """Find the most recent Sunday for Beginnings strips"""
+        import datetime
+        today = datetime.date.today()
+
+        # Find the most recent Sunday (0=Monday, 6=Sunday)
+        days_since_sunday = (today.weekday() + 1) % 7
+        if days_since_sunday == 0:  # Today is Sunday
+            most_recent_sunday = today
+        else:
+            most_recent_sunday = today - datetime.timedelta(days=days_since_sunday)
+
+        sunday_str = most_recent_sunday.strftime('%Y%m%d')
+        return f'https://leasticoulddo.com/comic/{sunday_str}'
+
+    stripUrl = 'https://leasticoulddo.com/comic/%s'
+    firstStripUrl = stripUrl % '20081109'  # First Sunday Beginnings strip
+    imageSearch = '//img[@class="comic-beginnings"]'  # Only Sunday strips
+    prevSearch = '//a[@rel="prev"]'
+    help = 'Index format: yyyymmdd (Sunday "Beginnings" strips)'
 
 class LetsSpeakEnglish(ComicControlScraper):
     url = 'http://www.marycagle.com'


### PR DESCRIPTION
## Add LeastICouldDoBeginnings scraper for Sunday strips

Fixes #285

The existing `LeastICouldDo` scraper fails on Sunday strips because they use a different CSS class (`comic-beginnings` instead of `comic`). This adds a separate scraper specifically for Sunday "Beginnings" strips.

### Changes:
- Added `LeastICouldDoBeginnings` class to `l.py`
- Automatically calculates most recent Sunday as starting point
- Uses `comic-beginnings` CSS class (vs `comic` for daily strips)
- Navigation should stay within Sunday strips only

### Root Cause:
Sunday strips use `<img class="comic-beginnings">` while weekday strips use `<img class="comic">`. The existing scraper's XPath `//img[d:class("comic")]` doesn't match Sunday strips.

### Testing:
- [x] Downloads current Sunday strip successfully (Sept 22, 2025)
- [x] Follows prev links to older Sunday strips
- [x] Creates separate `LeastICouldDoBeginnings` folder
- [x] Resolves the 404 error from issue #285

### Usage:
```bash
dosage LeastICouldDoBeginnings  # Downloads latest Sunday strip and works backwards